### PR TITLE
Remove home stats tiles and align dashboard styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,21 +17,8 @@ import { MantraList } from "@/components/mantra-list";
 import { Dashboard } from "@/components/dashboard";
 import { UserProfileDropdown } from "@/components/user-profile-dropdown";
 import { useAuth } from "@/lib/auth-context";
-import {
-  Download,
-  Upload,
-  Target,
-  Clock,
-  TrendingUp,
-  BookOpen,
-  BarChart,
-} from "lucide-react";
-import {
-  getMantras,
-  addMantra,
-  getCurrentStreak,
-  getTotalSessions,
-} from "@/lib/mantra-service";
+import { Download, Upload, BookOpen, BarChart } from "lucide-react";
+import { getMantras, addMantra } from "@/lib/mantra-service";
 import { Mantra } from "@/lib/types";
 import { DataExportService } from "@/lib/data-export-service";
 import { toast } from "sonner";
@@ -49,8 +36,6 @@ const OmLogo = ({ className }: { className?: string }) => (
 
 export default function Home() {
   const [mantras, setMantras] = useState<Mantra[]>([]);
-  const [streak, setStreak] = useState(0);
-  const [totalRepetitions, setTotalRepetitions] = useState(0);
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [activeTab, setActiveTab] = useState<"mantras" | "statistics">(
@@ -76,13 +61,6 @@ export default function Home() {
   const refreshData = () => {
     const updatedMantras = getMantras();
     setMantras(updatedMantras);
-    setStreak(getCurrentStreak());
-
-    // Calculate total repetitions across all mantras
-    const total = updatedMantras.reduce((sum, mantra) => {
-      return sum + getTotalSessions(mantra.id);
-    }, 0);
-    setTotalRepetitions(total);
   };
 
   useEffect(() => {
@@ -234,72 +212,6 @@ export default function Home() {
             <UserProfileDropdown />
           </div>
         </header>
-
-        {/* Stats Overview */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-          <Card className="border-0 shadow-lg gradient-surface">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-muted-foreground flex items-center">
-                <Target className="w-4 h-4 mr-2" />
-                Active Mantras
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-bold text-pink-600 dark:text-pink-400">
-                {mantras.length}
-              </div>
-              <p className="text-sm text-muted-foreground mt-1">
-                {mantras.length === 0
-                  ? "Start your journey"
-                  : mantras.length === 1
-                  ? "1 active mantra"
-                  : `${mantras.length} active mantras`}
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="border-0 shadow-lg gradient-surface">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-muted-foreground flex items-center">
-                <Clock className="w-4 h-4 mr-2" />
-                Total Repetitions
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-bold text-pink-600 dark:text-pink-400">
-                {totalRepetitions}
-              </div>
-              <p className="text-sm text-muted-foreground mt-1">
-                {totalRepetitions === 0
-                  ? "Begin today"
-                  : totalRepetitions === 1
-                  ? "1 repetition"
-                  : `${totalRepetitions} repetitions`}
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="border-0 shadow-lg gradient-surface">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-muted-foreground flex items-center">
-                <TrendingUp className="w-4 h-4 mr-2" />
-                Current Streak
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-bold text-pink-600 dark:text-pink-400">
-                {streak}
-              </div>
-              <p className="text-sm text-muted-foreground mt-1">
-                {streak === 0
-                  ? "Days in a row"
-                  : streak === 1
-                  ? "1 day streak"
-                  : `${streak} days streak`}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
 
         {/* Quick Access */}
         <Card className="border-0 shadow-xl mb-8 gradient-surface">

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -57,12 +57,18 @@ export function Dashboard() {
           <CardHeader className="pb-3">
             <CardTitle className="text-sm font-medium text-muted-foreground flex items-center">
               <Target className="w-4 h-4 mr-2" />
-              Total Mantras
+              Active Mantras
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-indigo-600 dark:text-indigo-400">{stats.totalMantras}</div>
-            <p className="text-sm text-muted-foreground mt-1">Active practices</p>
+            <div className="text-3xl font-bold text-pink-600 dark:text-pink-400">{stats.totalMantras}</div>
+            <p className="text-sm text-muted-foreground mt-1">
+              {stats.totalMantras === 0
+                ? 'Start your journey'
+                : stats.totalMantras === 1
+                ? '1 active mantra'
+                : `${stats.totalMantras} active mantras`}
+            </p>
           </CardContent>
         </Card>
 
@@ -74,8 +80,14 @@ export function Dashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-emerald-600 dark:text-emerald-400">{stats.totalSessions}</div>
-            <p className="text-sm text-muted-foreground mt-1">Repetitions tracked</p>
+            <div className="text-3xl font-bold text-pink-600 dark:text-pink-400">{stats.totalSessions}</div>
+            <p className="text-sm text-muted-foreground mt-1">
+              {stats.totalSessions === 0
+                ? 'Begin today'
+                : stats.totalSessions === 1
+                ? '1 repetition'
+                : `${stats.totalSessions} repetitions`}
+            </p>
           </CardContent>
         </Card>
 
@@ -87,8 +99,14 @@ export function Dashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-amber-600 dark:text-amber-400">{stats.currentStreak}</div>
-            <p className="text-sm text-muted-foreground mt-1">Days in a row</p>
+            <div className="text-3xl font-bold text-pink-600 dark:text-pink-400">{stats.currentStreak}</div>
+            <p className="text-sm text-muted-foreground mt-1">
+              {stats.currentStreak === 0
+                ? 'Days in a row'
+                : stats.currentStreak === 1
+                ? '1 day streak'
+                : `${stats.currentStreak} days streak`}
+            </p>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary
- remove the stats overview tiles from the home page
- adjust the statistics dashboard metric cards to use the home page styling and messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db5bde5a48832598d1056b7daebf77